### PR TITLE
Added the ability to check Wifi SSID

### DIFF
--- a/scripts/wifi-ssid
+++ b/scripts/wifi-ssid
@@ -2,3 +2,17 @@
 
 # Extract the wifi username (SSID)
 # Refer: "iw dev wlan0 link" command output for this
+iface=$(iw dev | awk '$1=="Interface"{print $2; exit}')
+
+if [ -z "$iface" ]; then
+  echo "No wireless interface found."
+  exit 1
+fi
+
+ssid=$(iw dev "$iface" link | awk -F 'SSID: ' '/SSID: / {print $2}')
+
+if [ -z "$ssid" ]; then
+  echo "Not connected to any Wi-Fi network on interface $iface."
+else
+  echo "Connected to SSID: $ssid on interface $iface"
+fi


### PR DESCRIPTION
[Resolves #1]

Using iw dev, the first wireless interface is selected
this is done because altho most systems have wlan0 as interface, mine had wlo1
so it was good to consider this
There is a check if the system even has a wireless interface
then using the interface name detected, we get the SSID
Example ->
![image](https://github.com/user-attachments/assets/85dbfc20-5fd6-46e7-8cac-802ba2787480)
