### PR TITLE
add script to retrieve currently connected wifi ssid

### DIFF
--- a/scripts/wifi-ssid
+++ b/scripts/wifi-ssid
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-# Extract the wifi username (SSID)
-# Refer: "iw dev wlan0 link" command output for this

--- a/scripts/wifi-ssid.sh
+++ b/scripts/wifi-ssid.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Extract the wifi username (SSID)
+# Refer: "iw dev wlan0 link" command output for this
+
+SSID=$(cmd.exe /c "netsh wlan show interfaces" | grep "SSID" | awk -F: '{print $2}' | xargs)
+
+echo "Currently connected Wi-Fi SSID: $SSID"


### PR DESCRIPTION
resolves #1 
Add script to retrieve currently connected Wi-Fi SSID in WSL using netsh command  because 
"iw dev wlan0 link" command is for only linux os
![Screenshot 2025-03-29 111731](https://github.com/user-attachments/assets/e7801751-ff1a-48ca-8cc7-3a773c827058)
