### PR TITLE
Added more color values and fixed the color script

### DIFF
--- a/scripts/color
+++ b/scripts/color
@@ -7,14 +7,21 @@ color() {
 }
 
 declare -A color_mapping=(
-    # TODO: Add more color values
-    # Refer bash color codes
+    ['black']=30
+    ['red']=31
+    ['green']=32
+    ['yellow']=33
+    ['blue']=34
     ['magenta']=35
+    ['cyan']=36
+    ['white']=37
 )
 
 if [[ $1 == 'reset' ]]; then
     color 0 00
+elif [[ -n "${color_mapping[$1]}" ]]; then
+    color 1 ${color_mapping[$1]} 
 else
-    color 1 ${color_mapping[$1]}
+    echo "Invalid color. The available colors are: ${!color_mapping[@]}" 
 fi
 


### PR DESCRIPTION
I have now added multiple colors along with magenta and modified the logic,it now checks the first argument provided by the user. If the argument is "reset", it resets the color settings. If the argument matches a valid color name from the color_mapping list, it applies that color. However, if the argument is not recognized, the script displays an error message along with a list of available colors.

Resolves #9 