### PR TITLE
fixed issue #1

### DIFF
--- a/scripts/wifi-ssid
+++ b/scripts/wifi-ssid
@@ -2,3 +2,11 @@
 
 # Extract the wifi username (SSID)
 # Refer: "iw dev wlan0 link" command output for this
+
+SSID=$(networksetup -getairportnetwork en0 | awk -F': ' '{print $2}')
+
+if [[ -n "$SSID" ]]; then
+    echo "Connected to: $SSID"
+else
+    echo "Not connected to any WiFi network."
+fi


### PR DESCRIPTION
Fixed Issue #1 
The value stored in the SSID variable is the current WiFi network name (SSID) for the en0 interface and the conditional statements checks if the variable SSID is not empty and output the respective result.