### PR TITLE
Formatted the output of cpu-temperature script

### DIFF
--- a/scripts/cpu-temperature
+++ b/scripts/cpu-temperature
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
-grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | cut -d':' -f1 | sed 's/label/input/' | xargs cat
+var=$(grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | cut -d':' -f1 | sed 's/label/input/' | xargs cat)
 
 # Following script outputs current cpu die temperature in milidegree-celcius, convert it to celcius and fahrenheit and display as:
 #
 # Celcius: 42.0 C
 # Fahrenheit: 107.6 F
+
+echo "Celcius: $(($var/1000)) C"
+echo "Fahrenheit: $(($var/1000*9/5+32)) F"


### PR DESCRIPTION
Made the temperature script better:

1.Output inndecimals - Now says "42.5" instead of "42"
2.Detailed explaination in output i.e it mentions wether it is in Celcsius or Fahrenheit

Resolves #8 