### PR TITLE
Completed the rm-gitignore script

### DIFF
--- a/scripts/rm-gitignore
+++ b/scripts/rm-gitignore
@@ -2,3 +2,15 @@
 
 # Removes all files written in .gitignore of any git repository (multiple) present inside current directory
 # To find list of all git repos inside current directory you can use: "find . -name .git -type d -prune"
+find . -name .git -type d -prune | while read -r git_dir; do
+    repo_dir="${git_dir%/.git}"  # Get repo directory
+    echo " Cleaning: $repo_dir"
+
+    if [[ -f "$repo_dir/.gitignore" ]]; then
+        (cd "$repo_dir" && git rm -r --cached -q -f -X . && git clean -fdX)
+    else
+        echo "No .gitignore found in $repo_dir"
+    fi
+done
+
+echo "✅ Cleanup complete!"


### PR DESCRIPTION
This script finds all Git repositories in the current directory and removes files listed in their .gitignore files. It ensures that only ignored files are deleted while keeping tracked files intact.

Resolves #3 