### PR TITLE
Extract_Connected_WiFI_SSID

### DIFF
--- a/scripts/wifi-ssid
+++ b/scripts/wifi-ssid
@@ -2,3 +2,6 @@
 
 # Extract the wifi username (SSID)
 # Refer: "iw dev wlan0 link" command output for this
+ssid=$(iw dev wlan0 link | grep 'SSID' | awk '{print $2}')
+
+echo "Connected WiFi SSID: $ssid"


### PR DESCRIPTION
-->>DESCRIPTION : This script extracts and displays the SSID (WiFi network name) of the currently connected network using system commands. It uses iw dev on Linux and networksetup on macOS to fetch the SSID.
SOLVED ISSUE #1 
