### PR TITLE
Script for Removing Git-Ignore Files

### DIFF
--- a/scripts/rm-gitignore
+++ b/scripts/rm-gitignore
@@ -2,3 +2,32 @@
 
 # Removes all files written in .gitignore of any git repository (multiple) present inside current directory
 # To find list of all git repos inside current directory you can use: "find . -name .git -type d -prune"
+
+# Function to check if a required command is available
+
+# Function to check if a required command(Good Practise)
+require() {
+    command -v "$1" >/dev/null 2>&1 || { echo "Error: $1 is not installed." >&2; exit 1; }
+}
+
+# Ensure required commands are available by calling above function
+require find
+require xargs
+require git
+
+# Find all Git repositories in the current directory
+find . -name .git -type d -prune | while read -r git_dir; do
+    repo_dir=$(dirname "$git_dir")
+    gitignore_file="$repo_dir/.gitignore"
+
+    # Check if .gitignore exists
+    if [[ -f "$gitignore_file" ]]; then
+        echo "Processing .gitignore in $repo_dir"
+
+        # Remove all files listed in .gitignore
+        git -C "$repo_dir" ls-files --ignored --exclude-standard | xargs -d '\n' rm -f
+        echo "Removed files listed in $gitignore_file"
+    else
+        echo "No .gitignore found in $repo_dir"
+    fi
+done

--- a/scripts/weather
+++ b/scripts/weather
@@ -2,3 +2,5 @@
 
 # TODO: Display weather of IIIT, Lucknow
 # For more information see: https://wttr.in/:help
+
+curl wttr.in/26.7984,81.0241

--- a/scripts/wifi-ssid
+++ b/scripts/wifi-ssid
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-# Extract the wifi username (SSID)
-# Refer: "iw dev wlan0 link" command output for this

--- a/scripts/wifi-ssid.ps1
+++ b/scripts/wifi-ssid.ps1
@@ -1,0 +1,22 @@
+# This script extracts the SSID of the currently connected WiFi network using PowerShell.
+
+try {
+    # Run netsh to get WiFi details
+    $wifiDetails = netsh wlan show interfaces 2>&1 | Out-String
+
+    # Extract the SSID from the output
+    $SSID = ($wifiDetails -split "`n" | Where-Object { $_ -match '^\s*SSID\s*:\s*' }) -replace '^\s*SSID\s*:\s*', ''
+
+    # Debugging: Print extracted SSID
+    Write-Output "Extracted SSID: $SSID"
+
+    # Check if SSID is found
+    if ([string]::IsNullOrWhiteSpace($SSID)) {
+        Write-Output "No WiFi SSID found. Are you connected to a network?"
+    } else {
+        Write-Output "Connected to WiFi SSID: $SSID"
+    }
+} catch {
+    # Handle any errors that occur during execution
+    Write-Output "An error occurred while running the script: $_"
+}


### PR DESCRIPTION
### #3 Add script to remove files listed in .gitignore
This PR creates a Bash script that removes all files listed in .gitignore files at the root of Git repositories within the current directory. The script ensures that all required commands (find, xargs, and git) are available before execution. It processes each Git repository using a _do-while loop_, checks for the presence of a .gitignore file, and removes the files listed in it.
