### PR TITLE
Added more special cases in extarrange script

### DIFF
--- a/scripts/extarrange
+++ b/scripts/extarrange
@@ -1,24 +1,26 @@
 #!/usr/bin/env bash
 
-# Arranges the files by grouping them into folder of their extension name
-# TODO: Run this script in your downloads folder
+# Arranges the files by grouping them into folders based on their extension
+# TODO: Run this script in your downloads folder or any target directory
 
 require() {
-    command -v "$1" 1>/dev/null || { >&2 echo "Error: $1 is not installed";exit 1; }
+    command -v "$1" 1>/dev/null || { >&2 echo "Error: $1 is not installed"; exit 1; }
 }
 
 require fd
 require egrep
 
 declare -A special_cases=(
-    ['^*.(tar.*|tbz)$']='tar'
-    # TODO: Add your own pattern here for similar file types appropriately
-    # Refer https://regex101.com/ & https://github.com/ziishaned/learn-regex/ for explaination and writing patterns
-    # These (regex) are same as ones used in sed command
+    ['\.(tar\.gz|tgz|tar\.bz2|tbz|tar\.xz|txz)$']='tar'    
+    ['\.(zip|rar|7z)$']='archives'                         
+    ['\.(jpg|jpeg|png|gif|bmp)$']='images'                
+    ['\.(mp4|mkv|avi|mov|flv)$']='videos'                 
+    ['\.(pdf|doc|docx|txt)$']='documents'                  
 )
 
 fd -tf -d1 \
 | while read file; do
+    echo "Processing file: $file"
     folder="$PWD/${file##*.}"
     for regex in "${!special_cases[@]}"; do
         (echo "$file" | egrep -q "$regex") && {
@@ -30,4 +32,3 @@ fd -tf -d1 \
     mkdir -p "$folder"
     mv "$file" "$folder"
 done
-


### PR DESCRIPTION
This PR is to solve issue #7 

First I understood the existing script. Special cases already exist for .tar.gz and .tgz files, treating them as .tar. 
Then I hae gone through the basics of regex;

[ .* → Matches anything
\.tar\.gz|\.tgz → Matches files ending in .tar.gz or .tgz
\.jpe?g → Matches .jpg or .jpeg
\.mp[34] → Matches .mp3 or .mp4
\.docx?|\.xlsx?|\.pptx? → Matches .doc, .docx, .xls, .xlsx, .ppt, .pptx]

Then modified the existing extarrange script accordingly.
I tested the script after that.
![image](https://github.com/user-attachments/assets/2cdea45d-91c9-4310-a98f-96d3f05e1f4e)
![image](https://github.com/user-attachments/assets/a5b69e75-57fb-47df-8164-09f5e76c1bd6)
![image](https://github.com/user-attachments/assets/b2477fc2-d747-4e53-a735-9882508ea04b)

Thank you!