### PR TITLE
ISSUE #6: Display permissions in Octal Format script

### DIFF
--- a/scripts/color
+++ b/scripts/color
@@ -9,6 +9,9 @@ color() {
 declare -A color_mapping=(
     # TODO: Add more color values
     # Refer bash color codes
+    ['red']=31
+    ['green']=32
+    ['blue']=34
     ['magenta']=35
 )
 
@@ -17,4 +20,3 @@ if [[ $1 == 'reset' ]]; then
 else
     color 1 ${color_mapping[$1]}
 fi
-

--- a/scripts/cpu-temperature
+++ b/scripts/cpu-temperature
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 
-grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | cut -d':' -f1 | sed 's/label/input/' | xargs cat
+temp-mc=$(grep -E 'Tctl|Tdie|Package id' /sys/class/hwmon/hwmon*/temp*_label | head -n1 | cut -d':' -f1 | sed 's/label/input/' | xargs cat)
 
+if[[-z $temp-mc]]; then
+    echo "Error: Unable to read CPU temperature."
+    exit 1
+fi
+temp-c=$(echo "scale=2; $temp-mc / 1000" | bc)
+temp-f=$(echo "scale=2; ($temp-c * 9/5) + 32" | bc)
+echo "Celcius: $temp-c C"
+echo "Fahrenheit: $temp-f F"
 # Following script outputs current cpu die temperature in milidegree-celcius, convert it to celcius and fahrenheit and display as:
 #
 # Celcius: 42.0 C

--- a/scripts/perms
+++ b/scripts/perms
@@ -7,3 +7,16 @@
 # 775 weather
 # 664 ../README.md
 
+if [$# -eq 0];then
+    echo "Usage: $0 file1 [file2 ...]"
+    exit 1
+fi
+for file in "$@";do
+    if [ -e "$file" ];then
+        perms=$(stat -c "%a" "$file")
+        echo "$perms $file"
+    else
+        echo "Error"
+    fi
+done
+


### PR DESCRIPTION
Resolves issue #6
Updated perms script to display file permissions in Octal Format.
Used stat to get file status from the provided file and implemented a for loop to iterate over all files.
![image](https://github.com/user-attachments/assets/2e9f91b5-d11b-404d-bddf-0469cfeed371)
