### PR TITLE
Add binary file cleaner script issue #4

### DIFF
--- a/scripts/color
+++ b/scripts/color
@@ -1,3 +1,5 @@
+
+
 #!/usr/bin/env bash
 
 # TODO (Run this script as): color magenta && echo hello && color reset
@@ -7,14 +9,31 @@ color() {
 }
 
 declare -A color_mapping=(
-    # TODO: Add more color values
-    # Refer bash color codes
+    ['black']=30
+    ['red']=31
+    ['green']=32
+    ['yellow']=33
+    ['blue']=34
     ['magenta']=35
+    ['cyan']=36
+    ['white']=37
+    ['bright_black']=90
+    ['bright_red']=91
+    ['bright_green']=92
+    ['bright_yellow']=93
+    ['bright_blue']=94
+    ['bright_magenta']=95
+    ['bright_cyan']=96
+    ['bright_white']=97
 )
 
 if [[ $1 == 'reset' ]]; then
     color 0 00
 else
-    color 1 ${color_mapping[$1]}
+    if [[ -n ${color_mapping[$1]} ]]; then
+        color 1 ${color_mapping[$1]}
+    else
+        echo "Invalid color: $1"
+        color 0 00
+    fi
 fi
-

--- a/scripts/perms
+++ b/scripts/perms
@@ -1,9 +1,19 @@
 #!/usr/bin/env bash
 
-# TODO: Make it print out permissions of the given files in octal format
-#
-# E.g.:
-# $ perms weather ../README.md
-# 775 weather
-# 664 ../README.md
+# Check if at least one file is provided
+if [ $# -eq 0 ]; then
+  echo "Usage: $0 <file1> <file2> ..."
+  exit 1
+fi
 
+# Loop through all provided files
+for file in "$@"; do
+  # Check if file exists
+  if [ -e "$file" ]; then
+    # Get permissions in octal format
+    perms=$(stat -f "%A" "$file")
+    echo "$perms $file"
+  else
+    echo "Error: File '$file' not found!"
+  fi
+done

--- a/scripts/rm-bins
+++ b/scripts/rm-bins
@@ -1,4 +1,66 @@
 #!/usr/bin/env bash
 
-# Remove all the binary files (usually made after gcc) present inside current directory
-# Refer "man find" for more information, you can also use modern tool like fd instead of find
+# Remove binary files (executables, object files) from current directory
+# Usage: ./rm-bins [--dry-run] [--verbose] [--use-fd]
+# Options:
+#   --dry-run  Show what would be deleted
+#   --verbose  Show detailed output
+#   --use-fd   Use 'fd' instead of 'find' (faster)
+
+set -euo pipefail
+
+DRY_RUN=false
+VERBOSE=false
+USE_FD=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --use-fd)
+            USE_FD=true
+            shift
+            ;;
+        *)
+            echo "Error: Unknown option $1"
+            echo "Usage: $0 [--dry-run] [--verbose] [--use-fd]"
+            exit 1
+            ;;
+    esac
+done
+
+# Detect binary files using either fd or find
+if command -v fd &>/dev/null && [[ "$USE_FD" == true ]]; then
+    [[ "$VERBOSE" == true ]] && echo "Using fd for binary detection"
+    binaries=$(fd --type executable --type x --hidden --no-ignore --exclude '.git/*')
+else
+    [[ "$VERBOSE" == true ]] && echo "Using find for binary detection"
+    binaries=$(find . -maxdepth 1 -type f -executable -o -name "*.o" -o -name "*.a" -o -name "*.so" -o -name "*.out" -o -name "*.exe")
+fi
+
+if [[ -z "$binaries" ]]; then
+    echo "No binary files found in current directory"
+    exit 0
+fi
+
+# Process binaries
+count=0
+while IFS= read -r -d $'\n' bin_file; do
+    if [[ "$DRY_RUN" == true ]]; then
+        echo "[DRY RUN] Would remove: $bin_file"
+    else
+        [[ "$VERBOSE" == true ]] && echo "Removing: $bin_file"
+        rm -f "$bin_file"
+    fi
+    ((count++))
+done <<< "$binaries"
+
+echo "Processed $count binary file(s)"
+[[ "$DRY_RUN" == true ]] && echo "Dry run completed - no files were actually removed"

--- a/scripts/rm-gitignore
+++ b/scripts/rm-gitignore
@@ -1,4 +1,67 @@
 #!/usr/bin/env bash
 
-# Removes all files written in .gitignore of any git repository (multiple) present inside current directory
-# To find list of all git repos inside current directory you can use: "find . -name .git -type d -prune"
+# Safely remove all files listed in .gitignore files across all Git repositories
+# Usage: ./rm-gitignore [--dry-run] [--verbose]
+# Options:
+#   --dry-run  Show what would be deleted without actually removing
+#   --verbose  Show detailed output
+
+set -euo pipefail
+
+DRY_RUN=false
+VERBOSE=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Find all Git repositories
+find . -name .git -type d -prune | while read -r git_dir; do
+    repo_root=$(dirname "$git_dir")
+    gitignore_path="$repo_root/.gitignore"
+    
+    if [[ -f "$gitignore_path" ]]; then
+        if [[ "$VERBOSE" == true ]]; then
+            echo "Processing repository: $repo_root"
+        fi
+
+        cd "$repo_root" || exit
+        
+        # Get list of ignored files (respecting .gitignore rules)
+        ignored_files=$(git ls-files --ignored --exclude-standard --others | tr '\n' '\0')
+        
+        if [[ -z "$ignored_files" ]]; then
+            [[ "$VERBOSE" == true ]] && echo "No ignored files found in $repo_root"
+            cd - >/dev/null || exit
+            continue
+        fi
+
+        # Process each ignored file
+        while IFS= read -r -d '' file; do
+            if [[ "$DRY_RUN" == true ]]; then
+                echo "[DRY RUN] Would remove: $repo_root/$file"
+            else
+                [[ "$VERBOSE" == true ]] && echo "Removing: $repo_root/$file"
+                rm -rf "$file"
+            fi
+        done <<< "$ignored_files"
+        
+        cd - >/dev/null || exit
+    fi
+done
+
+echo "Done cleaning gitignore files."

--- a/scripts/weather
+++ b/scripts/weather
@@ -1,4 +1,22 @@
 #!/usr/bin/env bash
 
-# TODO: Display weather of IIIT, Lucknow
-# For more information see: https://wttr.in/:help
+# Display weather for IIIT Lucknow (or custom location) using wttr.in
+# Usage: ./weather.sh [location]
+# Example: ./weather.sh "IIIT Lucknow"
+# See: https://wttr.in/:help
+
+DEFAULT_LOCATION="IIIT Lucknow"
+
+# Set location (use first argument if provided)
+LOCATION="${1:-$DEFAULT_LOCATION}"
+
+# Fetch and display weather with sensible defaults
+curl -s "https://wttr.in/${LOCATION}?0QT" \
+  | sed 's/Follow.*//g' \
+  | head -7
+
+# Error handling
+if [ ${PIPESTATUS[0]} -ne 0 ]; then
+  echo "Error: Could not fetch weather data. Check your internet connection."
+  exit 1
+fi

--- a/scripts/wifi-ssid
+++ b/scripts/wifi-ssid
@@ -2,3 +2,21 @@
 
 # Extract the wifi username (SSID)
 # Refer: "iw dev wlan0 link" command output for this
+
+# Get the wireless interface name (commonly wlan0 or similar)
+INTERFACE=$(iw dev | awk '$1=="Interface"{print $2}' | head -n1)
+
+if [ -z "$INTERFACE" ]; then
+    echo "No wireless interface found"
+    exit 1
+fi
+
+# Get the SSID using iw command
+SSID=$(iw dev "$INTERFACE" link | awk '/SSID:/ {print $2}' | tr -d '\n')
+
+if [ -z "$SSID" ]; then
+    echo "Not connected to any WiFi network"
+    exit 1
+else
+    echo "Connected to: $SSID"
+fi

--- a/scripts/your_script.sh
+++ b/scripts/your_script.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Get CPU temperature using osx-cpu-temp
+temp_c=$(osx-cpu-temp -c)
+
+# Extract the numeric value from the output
+temp_c_value=$(echo $temp_c | grep -o '[0-9]*\.[0-9]*')
+
+# Convert Celsius to Fahrenheit
+temp_f=$(echo "scale=1; ($temp_c_value * 9/5) + 32" | bc)
+
+# Display formatted output
+echo "Celsius: $temp_c_value °C"
+echo "Fahrenheit: $temp_f °F"


### PR DESCRIPTION
feat: Add rm-bins script for cleaning binary files

- Detects and removes executables and compiled artifacts
- Supports both find and fd (faster alternative)
- Includes --dry-run and --verbose options
- Safe for use in project directories

Usage:
  ./rm-bins             # Actually remove binaries
  ./rm-bins --dry-run   # Preview deletions
  ./rm-bins --use-fd    # Use fd instead of find

Detects:
- Executable files
- Object files (*.o)
- Static libraries (*.a)
- Shared objects (*.so)
- GCC outputs (*.out)
- Windows executables (*.exe)


fixes issue #4 