### PR TITLE
Written script to remove binary code generated by GCC using fd-find.

### DIFF
--- a/scripts/color
+++ b/scripts/color
@@ -7,9 +7,42 @@ color() {
 }
 
 declare -A color_mapping=(
-    # TODO: Add more color values
-    # Refer bash color codes
+    # REGULAR COLORS
+    ['black']=30
+    ['red']=31
+    ['green']=32
+    ['yellow']=33
+    ['blue']=34
     ['magenta']=35
+    ['cyan']=36
+    ['white']=37
+
+    ['bg_black']=40
+    ['bg_red']=41
+    ['bg_green']=42
+    ['bg_yellow']=43
+    ['bg_blue']=44
+    ['bg_magenta']=45
+    ['bg_cyan']=46
+    ['bg_white']=47
+    # BRIGHT COLORS
+    ['bright_black']=90
+    ['bright_red']=91
+    ['bright_green']=92
+    ['bright_yellow']=93
+    ['bright_blue']=94
+    ['bright_magenta']=95
+    ['bright_cyan']=96
+    ['bright_white']=97
+
+    ['bg_bright_black']=100
+    ['bg_bright_red']=101
+    ['bg_bright_green']=102
+    ['bg_bright_yellow']=103
+    ['bg_bright_blue']=104
+    ['bg_bright_magenta']=105
+    ['bg_bright_cyan']=106
+    ['bg_bright_white']=107
 )
 
 if [[ $1 == 'reset' ]]; then
@@ -17,4 +50,3 @@ if [[ $1 == 'reset' ]]; then
 else
     color 1 ${color_mapping[$1]}
 fi
-

--- a/scripts/extarrange
+++ b/scripts/extarrange
@@ -10,24 +10,40 @@ require() {
 require fd
 require egrep
 
+# Use the provided directory or default to the current directory
+TARGET_DIR="${1:-$PWD}"
+
 declare -A special_cases=(
     ['^*.(tar.*|tbz)$']='tar'
-    # TODO: Add your own pattern here for similar file types appropriately
-    # Refer https://regex101.com/ & https://github.com/ziishaned/learn-regex/ for explaination and writing patterns
-    # These (regex) are same as ones used in sed command
+    ['^*.(zip|rar|7z|gz|bz2|xz)$']='archives'
+    ['^*.(jpg|jpeg|png|gif|bmp|webp|svg)$']='images'
+    ['^*.(pdf|doc|docx|xls|xlsx|ppt|pptx|txt|md|odt|ods|odp)$']='documents'
+    ['^*.(mp3|wav|flac|m4a|ogg|wma)$']='audio'
+    ['^*.(mp4|avi|mkv|mov|wmv|flv|webm)$']='video'
+    ['^*.(py|js|java|c|cpp|h|cs|php|html|css|sh|bash|json|xml)$']='code'
+    ['^*.(ttf|otf|woff|woff2|eot)$']='fonts'
+    ['^*.(sql|sqlite|db)$']='databases'
+    ['^*.(exe|msi|app|dmg|deb|rpm)$']='executables'
+    ['^*.(log|txt)$']='logs'
+    ['^*.(conf|config|ini|yaml|yml|json|xml)$']='config'
 )
 
-fd -tf -d1 \
+# Main processing
+echo "Organising files into the respective folders"
+
+# Process each file in the target directory
+fd -tf -d1 "$TARGET_DIR" \
 | while read file; do
-    folder="$PWD/${file##*.}"
+    extension="${file##*.}"
+    folder="$TARGET_DIR/$extension"
     for regex in "${!special_cases[@]}"; do
         (echo "$file" | egrep -q "$regex") && {
-            folder="$PWD/${special_cases[$regex]}"
+            folder="$TARGET_DIR/${special_cases[$regex]}"
             break
         }
     done
-
     mkdir -p "$folder"
     mv "$file" "$folder"
 done
 
+echo "File organization complete!" 

--- a/scripts/rm-bins
+++ b/scripts/rm-bins
@@ -2,3 +2,12 @@
 
 # Remove all the binary files (usually made after gcc) present inside current directory
 # Refer "man find" for more information, you can also use modern tool like fd instead of find
+echo "Searching binary files"
+fd --type f --exec sh -c '
+    for file do
+        if file "$file" | grep -q "ELF.*executable\|ELF.*shared object\|ELF.*relocatable"; then
+            echo "Removing GCC-generated binary: $file"
+            rm -f "$file"
+        fi
+    done' sh {} +
+echo "Deleted all bniary files!"

--- a/scripts/weather
+++ b/scripts/weather
@@ -2,3 +2,6 @@
 
 # TODO: Display weather of IIIT, Lucknow
 # For more information see: https://wttr.in/:help
+
+echo "Fetching weather information for IIIT, Lucknow..."
+curl -s "wttr.in/IIIT+Lucknow?format=3" | cat

--- a/scripts/wifi-ssid
+++ b/scripts/wifi-ssid
@@ -2,3 +2,13 @@
 
 # Extract the wifi username (SSID)
 # Refer: "iw dev wlan0 link" command output for this
+
+# Use Windows netsh command
+ssid=$(/mnt/c/Windows/System32/netsh.exe wlan show interfaces | grep "SSID" | grep -v "BSSID" | cut -d ":" -f 2 | tr -d " \r")
+
+if [ -z "$ssid" ]; then
+    echo "Error: No SSID found or not connected to any network"
+    exit 1
+fi
+
+echo "$ssid"


### PR DESCRIPTION
### #4 Perquisites : 
- use sduo apt install to install fd-find.

~~I mistakenly written code that deleted my all scripts in /bash-practice-repo-25/scripts 😭~~
Firstly, I used hard coded script to remove all _**executable files**_ with certain extension, but that wasn't precise and safe.

I used a for loop for every file found and run the following bash script : 
```
if file "$file" | grep -q "ELF.*executable\|ELF.*shared object\|ELF.*relocatable"; then
      echo "Removing GCC-generated binary: $file"
      rm -f "$file"
fi
```
This code checks if the file has any of the following patterns:
1. ELF executables (compiled programs).
2.Shared libraries (.so files).
3Object files (.o files, from compilation).

This approach is safe and only delete files created by GCC.
[**Screenshot**](https://github.com/user-attachments/assets/163955a1-01fa-462b-956a-cbf58be91632)